### PR TITLE
Suggested changes to get stable JDBC connect URLs

### DIFF
--- a/pkg/drydock/drydock.go
+++ b/pkg/drydock/drydock.go
@@ -33,8 +33,14 @@ type Drydock struct {
 
 const internalPort = "5432"
 
-// New creates a new Drydock instance
+// New creates a new Drydock instance with a random password
 func New(image string) (*Drydock, error) {
+	dd, err := NewWithPassword(image, randomString())
+	return dd, err
+}
+
+// New creates a new Drydock instance with a constant password
+func NewWithPassword(image string, password string) (*Drydock, error) {
 	// Create temporary directory
 	tempDir, err := ioutil.TempDir("", "dock")
 	if err != nil {
@@ -58,7 +64,7 @@ func New(image string) (*Drydock, error) {
 		Image:    image,
 		DataDir:  tempDir,
 		Port:     port,
-		Password: randomString(),
+		Password: password,
 		client:   c,
 	}
 

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -30,5 +30,4 @@ func TestDrydock(t *testing.T) {
 	err = db.Select(&ids, "SELECT id FROM foo")
 	assert.Nil(t, err)
 	assert.Equal(t, 1000, len(ids))
-
 }

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -1,10 +1,26 @@
 package drydock
 
 import (
+	"fmt"
+	"github.com/jmoiron/sqlx"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNamedDatabase(t *testing.T) {
+	dd, err := New("postgres:latest")
+	assert.Nil(t, err)
+	t.Cleanup(func() { dd.Terminate() })
+
+	dbName := "db_foobarjalla"
+	db, err := dd.NewDBConnToNamedDb(dbName)
+	assert.Nil(t, err)
+	defer db.Close()
+
+	fmt.Println("JDBC connect string = ", dd.JdbcConnectString(dbName))
+	createAndSelectSomeValues(t, err, db)
+}
 
 func TestDrydock(t *testing.T) {
 	dd, err := New("postgres:latest")
@@ -15,6 +31,10 @@ func TestDrydock(t *testing.T) {
 	assert.Nil(t, err)
 	defer db.Close()
 
+	createAndSelectSomeValues(t, err, db)
+}
+
+func createAndSelectSomeValues(t *testing.T, err error, db *sqlx.DB) {
 	_, err = db.Exec("CREATE TABLE foo (id INTEGER NOT NULL)")
 	assert.Nil(t, err)
 

--- a/pkg/drydock/drydock_test.go
+++ b/pkg/drydock/drydock_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestNamedDatabase(t *testing.T) {
-	dd, err := New("postgres:latest")
+	password := "verySekrit"
+	dd, err := NewWithPassword("postgres:latest", password)
 	assert.Nil(t, err)
 	t.Cleanup(func() { dd.Terminate() })
 


### PR DESCRIPTION
**Rationale**

When using external database viewers, such as "datagrip", "pgadmin" or the database tooling in the Jetbrains suite of IDEs, it is very convenient to have a jdbc database URL that is constant over time.  The proposed changes adds functionality to do that.

The changes are conservative with respect to the original API, but it does rewrite the tests a bit, and the way things are changed may not be to your liking.  Please give feedback on these issues.

**API**

This code will now do the obvious thing:


```

 func TestNamedDatabase(t *testing.T) {
	password := "verySekrit"
	dd, err := NewWithPassword("postgres:latest", password)
	assert.Nil(t, err)
	t.Cleanup(func() { dd.Terminate() })

	dbName := "db_foobarjalla"
	db, err := dd.NewDBConnToNamedDb(dbName)
	assert.Nil(t, err)
	defer db.Close()

	fmt.Println("JDBC connect string = ", dd.JdbcConnectString(dbName))
	createAndSelectSomeValues(t, err, db)
}

```





